### PR TITLE
Fix case class/object highlighting

### DIFF
--- a/syntax/syntaxes/Scala.tmLanguage
+++ b/syntax/syntaxes/Scala.tmLanguage
@@ -418,6 +418,23 @@
 						<key>2</key>
 						<dict>
 							<key>name</key>
+							<string>entity.name.class.declaration</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b(trait)\s+([^\s\{\(\[]+)</string>
+				</dict>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>keyword.declaration.scala</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
 							<string>keyword.declaration.scala</string>
 						</dict>
 						<key>3</key>
@@ -427,7 +444,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(case)?\b(class|trait|object)\s+([^\s\{\(\[]+)</string>
+					<string>\b(?:(case)\s+)?(class|object)\s+([^\s\{\(\[]+)</string>
 				</dict>
 				<dict>
 					<key>captures</key>


### PR DESCRIPTION
Hi maintainers,

**Problem.** The `case` keyword is assigned the scope `keyword.control.flow.scala` in the declarations `case class` and `case object`. This seems incorrect. See the image below.

![screenshot-before](https://user-images.githubusercontent.com/246905/54174512-1a3a3d00-4444-11e9-8589-e7967df5b373.png)

**Proposal.** After investigating, I discovered that the corresponding pattern did not account for whitespace between the `case` keyword and the `class`/`object` keywords. To fix this, we propose two changes in this PR:

- matched potential whitespace between `case` and `class`/`object` declarations and
- extracted an independent pattern for the `trait` declarations because they cannot be preceded by a `case` keyword.

The image below shows the result after these changes have been applied.

![screenshot-after](https://user-images.githubusercontent.com/246905/54174514-1c9c9700-4444-11e9-95e7-c98d85f176bb.png)
