### PR TITLE
Add auto-closing pair settings for string interpolation

### DIFF
--- a/syntax/language-configuration.json
+++ b/syntax/language-configuration.json
@@ -17,6 +17,9 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
+        ["s\"", "\""],
+        ["f\"", "\""],
+        ["raw\"", "\""],
         ["'", "'"]
     ],
     // symbols that that can be used to surround a selection


### PR DESCRIPTION
I've added auto-closing pairs for all out-of-the-box supported [String interpolators](https://docs.scala-lang.org/overviews/core/string-interpolation.html) (`s`, `f` & `raw`). 

Previously, when typing `s"` no extra `"` would be added. Typing another `"` would result in `s"""` (three quotes).

Now when `s"` is typed, the result is `s""`, with the cursor between the quotes

[Before](https://i.imgur.com/xwmy0xd.mp4)

[After](https://i.imgur.com/uRVrmTX.mp4)