### PR TITLE
Welcome PanAeon to the team!

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ files.
 
 This repo also powers the Scala syntax highlighting on GitHub. (It is vendored in [github/linguist](https://github.com/github/linguist).)
 
+### Team
+
+The current maintainers (people who can merge pull requests) are:
+
+- Olafur Pall Geirsson - [`@olafurpg`](https://github.com/olafurpg)
+- Nicolas Stucki- [`@nicolasstucki`](https://github.com/nicolasstucki)
+- Vitalii Voloshyn - [`@PanAeon`](https://github.com/PanAeon)
+- all other members of the Scala organization on GitHub
+
 ## Based on
 
 - Plugin: https://github.com/daltonjorge/vscode-scala


### PR DESCRIPTION
PanAeon has made so many valuable contributions to the VS Code Scala
Syntax highlighting rules:

- translate the old XML file into TypeScript
- fix highlighting for string interpolators, nested comments, non-ascii
  identifiers, symbol literals, ..., the list goes on.

Thank you so much for your work!

@PanAeon you should have received a collaborator invite via https://github.com/scala/vscode-scala-syntax/invitations. Feel free to merge this PR once you have accepted the invite.