### PR TITLE
Fix #103: Detect `as`

### DIFF
--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -75,7 +75,7 @@ export const scalaTmLanguage: TmLanguage = {
               match: `(?x)(given\\s)?\\s*(?:(${idUpper})|(${backQuotedId}|${plainid}))\\s*(=>)\\s*(?:(${idUpper})|(${backQuotedId}|${plainid}))\\s*`,
               captures: {
                 '1': {
-                  name: 'keyword.import.given.scala'
+                  name: 'keyword.other.import.given.scala'
                 },
                 '2': {
                   name: 'entity.name.class.import.renamed-from.scala'
@@ -98,7 +98,7 @@ export const scalaTmLanguage: TmLanguage = {
               match: `(given\\s+)?(?:(${idUpper})|(${backQuotedId}|${plainid}))`,
               captures: {
                 '1': {
-                  name: 'keyword.import.given.scala'
+                  name: 'keyword.other.import.given.scala'
                 },
                 '2': {
                   name: 'entity.name.class.import.scala'

--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -75,7 +75,7 @@ export const scalaTmLanguage: TmLanguage = {
               match: `(?x)(given\\s)?\\s*(?:(${idUpper})|(${backQuotedId}|${plainid}))\\s*(=>)\\s*(?:(${idUpper})|(${backQuotedId}|${plainid}))\\s*`,
               captures: {
                 '1': {
-                  name: 'keyword.other.given.scala'
+                  name: 'keyword.import.given.scala'
                 },
                 '2': {
                   name: 'entity.name.class.import.renamed-from.scala'
@@ -98,7 +98,7 @@ export const scalaTmLanguage: TmLanguage = {
               match: `(given\\s+)?(?:(${idUpper})|(${backQuotedId}|${plainid}))`,
               captures: {
                 '1': {
-                  name: 'keyword.given.import.scala'
+                  name: 'keyword.import.given.scala'
                 },
                 '2': {
                   name: 'entity.name.class.import.scala'
@@ -127,7 +127,7 @@ export const scalaTmLanguage: TmLanguage = {
           name: 'keyword.other.export.scala'
         },
         '2': {
-          name: 'keyword.other.given.scala'
+          name: 'keyword.other.export.given.scala'
         }
       },
       patterns: [
@@ -245,6 +245,9 @@ export const scalaTmLanguage: TmLanguage = {
         },
         {
           include: '#using'
+        },
+        {
+          include: '#as'
         },
         {
           include: '#constants'
@@ -409,6 +412,16 @@ export const scalaTmLanguage: TmLanguage = {
             '1': {
               name: 'keyword.declaration.scala'
             }
+          }
+        }
+      ]
+    },
+    'as': {
+      patterns: [
+        {
+          match: '\\s(as)\\s',
+          captures: {
+            '1': { name: 'keyword.declaration.scala' }
           }
         }
       ]
@@ -692,6 +705,20 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           name: 'meta.package.scala'
+        },
+        {
+          match: `\\b(given)\\s+(as)\\s`,
+          captures: {
+            '1': { name: 'keyword.declaration.scala' },
+            '2': { name: 'keyword.declaration.scala' }
+          }
+        },
+        {
+          match: `\\b(given)\\s+(${backQuotedId}|${plainid})?`,
+          captures: {
+            '1': { name: 'keyword.declaration.scala' },
+            '2': { name: 'entity.name.declaration' }
+          }
         }
       ]
     },
@@ -802,7 +829,7 @@ export const scalaTmLanguage: TmLanguage = {
           name: 'storage.modifier.access'
         },
         {
-          match: '\\b(synchronized|@volatile|abstract|final|lazy|sealed|implicit|given|enum|inline |opaque |override|@transient|@native)\\b',
+          match: '\\b(synchronized|@volatile|abstract|final|lazy|sealed|implicit|enum|inline |opaque |override|@transient|@native)\\b',
           name: 'storage.modifier.other'
         }
       ]

--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -707,17 +707,11 @@ export const scalaTmLanguage: TmLanguage = {
           name: 'meta.package.scala'
         },
         {
-          match: `\\b(given)\\s+(as)\\s`,
+          match: `\\b(given)\\b\\s*(?:\\b(as)\\b|(${backQuotedId}|(?!//|/\\*)${plainid})?)`,
           captures: {
             '1': { name: 'keyword.declaration.scala' },
-            '2': { name: 'keyword.declaration.scala' }
-          }
-        },
-        {
-          match: `\\b(given)\\s+(${backQuotedId}|${plainid})?`,
-          captures: {
-            '1': { name: 'keyword.declaration.scala' },
-            '2': { name: 'entity.name.declaration' }
+            '2': { name: 'keyword.declaration.scala' },
+            '3': { name: 'entity.name.declaration' }
           }
         }
       ]

--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -247,9 +247,6 @@ export const scalaTmLanguage: TmLanguage = {
           include: '#using'
         },
         {
-          include: '#as'
-        },
-        {
           include: '#constants'
         },
         {
@@ -416,16 +413,6 @@ export const scalaTmLanguage: TmLanguage = {
         }
       ]
     },
-    'as': {
-      patterns: [
-        {
-          match: '\\s(as)\\s',
-          captures: {
-            '1': { name: 'keyword.declaration.scala' }
-          }
-        }
-      ]
-    },
     'string-interpolation': {
       patterns: [
         {
@@ -559,6 +546,12 @@ export const scalaTmLanguage: TmLanguage = {
         {
           match: '(<-|←|->|→|=>|⇒|\\?|\\:+|@|\\|)+',
           name: 'keyword.operator.scala'
+        },
+        {
+          match: '\\s(as)\\s',
+          captures: {
+            '1': { name: 'keyword.declaration.scala' }
+          }
         }
       ]
     },

--- a/tests/unit/#103.test.scala
+++ b/tests/unit/#103.test.scala
@@ -67,3 +67,21 @@
 //                                                                           ^^^ constant.character.literal.scala
 //                                                                               ^^^^ keyword.control.flow.scala
 //                                                                                    ^ constant.numeric.scala
+
+    given // this should be a comment
+//  ^^^^^ keyword.declaration.scala
+//        ^^ punctuation.definition.comment.scala
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.scala
+        as Foo
+//      ^^ keyword.declaration.scala
+
+    given// this should be a comment
+//  ^^^^^ keyword.declaration.scala
+//       ^^ punctuation.definition.comment.scala
+//          ^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.scala
+
+    given /* this should be a comment */
+//  ^^^^^ keyword.declaration.scala
+//        ^^ punctuation.definition.comment.scala
+//          ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.scala
+//                                    ^^ punctuation.definition.comment.scala

--- a/tests/unit/#103.test.scala
+++ b/tests/unit/#103.test.scala
@@ -1,0 +1,69 @@
+// SYNTAX TEST "source.scala"
+
+    given as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//        ^^ keyword.declaration.scala
+
+    given foo as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.declaration
+//            ^^ keyword.declaration.scala
+
+    given (x: X) as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//         ^ variable.parameter.scala
+//          ^ meta.colon.scala
+//            ^ entity.name.class
+//               ^^ keyword.declaration.scala
+
+    given [X](x: X) as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//         ^ entity.name.class
+//            ^ variable.parameter.scala
+//             ^ meta.colon.scala
+//               ^ entity.name.class
+//                  ^^ keyword.declaration.scala
+
+    given foo(x: A) as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.declaration
+//            ^ variable.parameter.scala
+//             ^ meta.colon.scala
+//               ^ entity.name.class
+//                  ^^ keyword.declaration.scala
+
+    given foo[X](x: X) as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.declaration
+//            ^ entity.name.class
+//               ^ variable.parameter.scala
+//                ^ meta.colon.scala
+//                  ^ entity.name.class
+//                     ^^ keyword.declaration.scala
+
+    given foo[X <: Y { type A = 1; def f(using a: Int): 2 }](x: X = 2) as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.declaration
+//                     ^^^^ keyword.declaration.scala
+//                              ^ constant.numeric.scala
+//                                 ^^^ keyword.declaration.scala
+//                                     ^ entity.name.function.declaration
+//                                       ^^^^^ keyword.declaration.scala
+//                                             ^ variable.parameter.scala
+//                                              ^ meta.colon.scala
+//                                                ^^^ entity.name.class
+//                                                      ^ constant.numeric.scala
+//                                                                  ^ constant.numeric.scala
+
+    given (using x: X = "abs")(using y: Y = s"y: $x", y: Char = if true then 'a' else 2) as Foo = ...
+//  ^^^^^ keyword.declaration.scala
+//                      ^^^^^ string.quoted.double.scala
+//                                          ^ keyword.interpolation.scala
+//                                           ^^^^ string.quoted.double.interpolated.scala
+//                                               ^^ meta.template.expression.scala
+//                                                              ^^ keyword.control.flow.scala
+//                                                                 ^^^^ constant.language.scala
+//                                                                      ^^^^ keyword.control.flow.scala
+//                                                                           ^^^ constant.character.literal.scala
+//                                                                               ^^^^ keyword.control.flow.scala
+//                                                                                    ^ constant.numeric.scala

--- a/tests/unit/imports.test.scala
+++ b/tests/unit/imports.test.scala
@@ -48,7 +48,7 @@
 //         ^ meta.import.scala entity.name.import.scala
 //          ^ meta.import.scala punctuation.definition.import
 //           ^ meta.import.scala meta.import.selector.scala meta.bracket.scala
-//            ^^^^^ meta.import.scala keyword.import.given.scala
+//            ^^^^^ meta.import.scala keyword.other.import.given.scala
 //                 ^ meta.import.scala meta.import.selector.scala
 //                  ^ meta.import.scala entity.name.import.scala
 //                   ^ meta.import.scala meta.import.selector.scala
@@ -59,7 +59,7 @@
 //         ^ meta.import.scala entity.name.class.import.scala
 //          ^ meta.import.scala punctuation.definition.import
 //           ^ meta.import.scala meta.import.selector.scala meta.bracket.scala
-//            ^^^^^ meta.import.scala keyword.import.given.scala
+//            ^^^^^ meta.import.scala keyword.other.import.given.scala
 //                 ^ meta.import.scala meta.import.selector.scala
 //                  ^^ meta.import.scala entity.name.class.import.scala
 //                    ^ meta.import.scala meta.import.selector.scala

--- a/tests/unit/imports.test.scala
+++ b/tests/unit/imports.test.scala
@@ -48,7 +48,7 @@
 //         ^ meta.import.scala entity.name.import.scala
 //          ^ meta.import.scala punctuation.definition.import
 //           ^ meta.import.scala meta.import.selector.scala meta.bracket.scala
-//            ^^^^^ meta.import.scala keyword.given.import.scala
+//            ^^^^^ meta.import.scala keyword.import.given.scala
 //                 ^ meta.import.scala meta.import.selector.scala
 //                  ^ meta.import.scala entity.name.import.scala
 //                   ^ meta.import.scala meta.import.selector.scala
@@ -59,7 +59,7 @@
 //         ^ meta.import.scala entity.name.class.import.scala
 //          ^ meta.import.scala punctuation.definition.import
 //           ^ meta.import.scala meta.import.selector.scala meta.bracket.scala
-//            ^^^^^ meta.import.scala keyword.given.import.scala
+//            ^^^^^ meta.import.scala keyword.import.given.scala
 //                 ^ meta.import.scala meta.import.selector.scala
 //                  ^^ meta.import.scala entity.name.class.import.scala
 //                    ^ meta.import.scala meta.import.selector.scala


### PR DESCRIPTION
A variant of #115.

This implementation may have some false positives for the `as` but will be more stable when writing a given definition.
We decided to try out this version and see how it behaves in larger projects. If we see some problems that cannot be addressed with this architecture we will consider the approach in #115.