### PR TITLE
Improve highlighting of names in given declarations

### DIFF
--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -708,11 +708,12 @@ export const scalaTmLanguage: TmLanguage = {
           name: 'meta.package.scala'
         },
         {
-          match: `\\b(given)\\b\\s*(?:\\b(as)\\b|(${backQuotedId}|(?!//|/\\*)${plainid})?)`,
+          match: `\\b(given)\\b\\s*(?:\\b(as)\\b|(${idUpper})|(${backQuotedId}|(?!//|/\\*)${plainid})?)`,
           captures: {
             '1': { name: 'keyword.declaration.scala' },
             '2': { name: 'keyword.declaration.scala' },
-            '3': { name: 'entity.name.declaration' }
+            '3': { name: 'entity.name.type.declaration' },
+            '4': { name: 'entity.name.declaration' },
           }
         }
       ]

--- a/tests/unit/given.test.scala
+++ b/tests/unit/given.test.scala
@@ -1,0 +1,32 @@
+// SYNTAX TEST "source.scala"
+
+
+    given Foo = ???
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.type.declaration
+  
+    given foo = ???
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.declaration
+  
+    given as Foo = ???
+//  ^^^^^ keyword.declaration.scala
+//        ^^ keyword.declaration.scala
+//           ^^^ entity.name.class
+
+    given as foo = ???
+//  ^^^^^ keyword.declaration.scala
+//        ^^ keyword.declaration.scala
+//           ^^^ source.scala
+
+    given bar as foo = ???
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.declaration
+//            ^^ keyword.declaration.scala
+//               ^^^ source.scala
+
+    given Foo as foo = ???
+//  ^^^^^ keyword.declaration.scala
+//        ^^^ entity.name.type.declaration
+//            ^^ keyword.declaration.scala
+//               ^^^ source.scala


### PR DESCRIPTION
Upper cased names are higlighted as types like with module declarations.
This also aligns with the explicit use sites of given declarations.