### PR TITLE
Fix #75: Fix Travis CI deployments from branches other than master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,5 +22,6 @@ jobs:
           secure: Gwd3nyoQSSZZTMrH8LgD4gwzXjfaPjQfrsFVvtSvoV+xcDI79crg0YQ2mClmVCnKAch6Pup/T84Os9swPKWcKJeHnZ2PxFA5FlIp4iZH5CbEODz9R7Pxqwq/qGqkAZOzr/K7W4g2NEs21IbcJKxsWlhlRhH+1m2iR397zleWduy3pkzJI0SqrdcRy34otYoCovxztnf47VmOq49HhfQdnYbOdtQTsDLJrtB7G1xXnWtDLCkFLOM1D2/bNeWaHOaSXO8hXGdC9EoAjMdmG4gauBp0VmXgHy9y+7dY0QBgFUcJdDDIfVURiiLPD/ka1/6JPigvYxPMbkXOZq8Io/3p6fZMBrtO8nqVvQKTTezU3d4GQ3zITZ84pol574MrR5gst0m9ph8gdYCNCGaJ6MZXGj/cYyIx5vswSBudK7jW75vpQyFW5iv9XE4gO9A0QsrutsIq6fe/WSNekDySHdWNdQ+JbtzK+BiyAFzu3YepytNYY2Bk8c71UpY5FUx2kkbZbLR8wGVipKn3U5W8azXFBWFRRO6yYYEXp/pcv/uCK4io9FNLotiZeZuiTs4B6X3tba3ZuV0XUI1lIwl3B+JQPggNVIH897K3Ge77+rEKoKuTvQg78U9uw41h4IjdHIjRT0aEQ+MWXj/O8Jo17B1XQvoBYdc4C9vtGW4NmmR+hmw=
         on:
           repo: scala/vscode-scala-syntax
+          all_branches: true
 
 cache: yarn


### PR DESCRIPTION
The [previous deployment](https://travis-ci.org/github/scala/vscode-scala-syntax/jobs/710711909) failed with the following message:

```
Skipping a deployment with the releases provider because this branch is not permitted: 0.4.2
```

It turns out that the previous config only allowed deployments from `master`. According to the [Travis CI docs](https://docs.travis-ci.com/user/deployment#conditional-releases-with-on):

>  `branch`: name of the branch. If omitted, this defaults to the app-specific branch, or `master`. If the branch name is not known ahead of time, you can specify `all_branches: true` instead of `branch:` and use other conditions to control your deployment.

In our case, we already only deploy if a tag is present, so `all_branches: true` should be fine.

Hopefully it'll work this time :crossed_fingers: 