### PR TITLE
Fix #133: Highlight inline as a soft keyword

### DIFF
--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -264,6 +264,9 @@ export const scalaTmLanguage: TmLanguage = {
           include: '#singleton-type'
         },
         {
+          include: '#inline'
+        },
+        {
           include: '#scala-quoted'
         },
         {
@@ -571,6 +574,26 @@ export const scalaTmLanguage: TmLanguage = {
         }
       }
     },
+    inline: {
+      patterns: [
+        {
+          match: `\\b(inline)\\b(?=(\\s+(?:${plainid}|${backQuotedId})\\s*:)|(.*(val|def)))`,
+          captures: {
+            '1': {
+              name: 'storage.modifier.other'
+            }
+          }
+        },
+        {
+          match: `\\b(inline)\\b(?=.*(if|match))`,
+          captures: {
+            '1': {
+              name: 'keyword.control.flow.scala'
+            }
+          }
+        }
+      ]
+    },
     'scala-quoted': {
       match: "('\\{|'\\[)(?!')",
       name: 'constant.other.quoted.scala'
@@ -822,7 +845,7 @@ export const scalaTmLanguage: TmLanguage = {
           name: 'storage.modifier.access'
         },
         {
-          match: '\\b(synchronized|@volatile|abstract|final|lazy|sealed|implicit|inline |opaque |override|@transient|@native)\\b',
+          match: '\\b(synchronized|@volatile|abstract|final|lazy|sealed|implicit|opaque |override|@transient|@native)\\b',
           name: 'storage.modifier.other'
         }
       ]

--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -577,18 +577,18 @@ export const scalaTmLanguage: TmLanguage = {
     inline: {
       patterns: [
         {
-          match: `\\b(inline)\\b(?=(\\s+(?:${plainid}|${backQuotedId})\\s*:)|(.*(val|def)))`,
+          match: `\\b(inline)\\b(?=(?:.(?!val|def|given))*(if|match))`,
           captures: {
             '1': {
-              name: 'storage.modifier.other'
+              name: 'keyword.control.flow.scala'
             }
           }
         },
         {
-          match: `\\b(inline)\\b(?=.*(if|match))`,
+          match: `\\b(inline)\\s+(?=(([\\w\\s]*(val|def|given))|(${plainid}|${backQuotedId})\\s*:))`,
           captures: {
             '1': {
-              name: 'keyword.control.flow.scala'
+              name: 'storage.modifier.other'
             }
           }
         }

--- a/tests/unit/#133.test.scala
+++ b/tests/unit/#133.test.scala
@@ -39,3 +39,15 @@ val x = inline[T]
 //             ^^^^^^ entity.name.function.declaration
 //                    ^^^^^^ storage.modifier.other
 //                           ^^^^^^ variable.parameter.scala
+
+   inline if (n == 0) 1 else 2; val x = 2
+// ^^^^^^ keyword.control.flow.scala
+//        ^^ keyword.control.flow.scala
+
+   inline if (n == 0) 1 else 2; def x = 2
+// ^^^^^^ keyword.control.flow.scala
+//        ^^ keyword.control.flow.scala
+
+    inline f[X](x: X) match {
+//  ^^^^^^ keyword.control.flow.scala
+//                    ^^^^^ keyword.control.flow.scala

--- a/tests/unit/#133.test.scala
+++ b/tests/unit/#133.test.scala
@@ -1,0 +1,41 @@
+// SYNTAX TEST "source.scala"
+
+
+    inline val c = 0
+//  ^^^^^^ storage.modifier.other
+
+    inline def power(x: Double, inline n: Int): Double =
+//  ^^^^^^ storage.modifier.other
+//                              ^^^^^^ storage.modifier.other
+      inline if (n == 0) 1.0
+//    ^^^^^^ keyword.control.flow.scala
+      else inline if (n % 2 == 1) x * power(x, n - 1)
+//         ^^^^^^ keyword.control.flow.scala
+      else power(x * x, n / 2)
+ 
+
+    inline x match {
+//  ^^^^^^ keyword.control.flow.scala
+//           ^^^^^ keyword.control.flow.scala
+
+
+    inline def power(x: Double, inline N: Int): Double =
+//  ^^^^^^ storage.modifier.other
+//                              ^^^^^^ storage.modifier.other
+
+    inline def power(x: Double, inline `n`: Int): Double =
+//  ^^^^^^ storage.modifier.other
+//                              ^^^^^^ storage.modifier.other
+
+val x = inline + 2
+//      ^^^^^^ - storage.modifier.other keyword.control.flow.scala
+val x = inline(x)
+//      ^^^^^^ - storage.modifier.other keyword.control.flow.scala
+val x = inline[T]
+//      ^^^^^^ - storage.modifier.other keyword.control.flow.scala
+
+    inline def inline(inline inline: Int): Double =
+//  ^^^^^^ storage.modifier.other
+//             ^^^^^^ entity.name.function.declaration
+//                    ^^^^^^ storage.modifier.other
+//                           ^^^^^^ variable.parameter.scala

--- a/tests/unit/#139.test.scala
+++ b/tests/unit/#139.test.scala
@@ -1,0 +1,10 @@
+// SYNTAX TEST "source.scala"
+
+
+    inline def mkDefaultTypeable[T]: Typeable[T] = ${ TypeableMacros.impl[T] }
+//  ^^^^^^ storage.modifier.other
+//         ^^^ keyword.declaration.scala
+
+    inline given [T] as Typeable[T] = mkDefaultTypeable[T]
+//  ^^^^^^ storage.modifier.other
+//         ^^^^^ keyword.declaration.scala


### PR DESCRIPTION
If it is part of an inline `if` or `match` it is highlighted as a control flow keyword.
If it is part of a `def` or `val` definition it is highlighted as a declaration keyword.
Otherwise, it is not highlighted.

<img width="349" alt="Screenshot 2020-08-21 at 19 13 18" src="https://user-images.githubusercontent.com/3648029/90917063-70096780-e3e2-11ea-88c5-970ac3778e47.png">
