### PR TITLE
Fix typo in workflow name for Github actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,4 @@
-name: continuos-integration
+name: continuous-integration
 
 on: [push, pull_request]
 


### PR DESCRIPTION
`continuos` -> `continuous`