### PR TITLE
Fix extension build warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "vscode:publish": "vsce publish --yarn",
         "build": "npm-run-all build:syntax build:extension",
         "build:syntax": "ts-node src/typescript/GenerateTmLanguageFile.ts > ./syntaxes/Scala.tmLanguage.json",
-        "build:extension": "vsce package",
+        "build:extension": "vsce package --yarn",
         "test": "npm-run-all test:*",
         "test:unit": "vscode-tmgrammar-test -s source.scala -g syntaxes/Scala.tmLanguage.json -t 'tests/unit/**/*.test.scala'",
         "test:snap": "vscode-tmgrammar-snap -s source.scala -g syntaxes/Scala.tmLanguage.json -t 'tests/snap/**/*.test.scala'"


### PR DESCRIPTION
Fixes the following warning from `yarn build`:

```
 INFO  Detected presense of yarn.lock. Using 'yarn' instead of 'npm' (to override this pass '--no-yarn' on the command line).
```

See info from `vsce --help`:

```console
$ npx vsce help package
Usage: vsce package [options]

Packages an extension

Options:
  -o, --out [path]         Output .vsix extension file to [path] location
  --githubBranch [branch]  The GitHub branch used to infer relative links in README.md. Can be overriden by --baseContentUrl and --baseImagesUrl.
  --baseContentUrl [url]   Prepend all relative links in README.md with this url.
  --baseImagesUrl [url]    Prepend all relative image links in README.md with this url.
  --yarn                   Use yarn instead of npm (default inferred from presense of yarn.lock or .yarnrc)
  --no-yarn                Use npm instead of yarn (default inferred from lack of yarn.lock or .yarnrc)
  --ignoreFile [path]      Indicate alternative .vscodeignore
  --noGitHubIssueLinking   Prevent automatic expansion of GitHub-style issue syntax into links
  --web                    Experimental flag to enable publishing web extensions. Note: This is supported only for selected extensions.
  -h, --help               display help for command
```