### PR TITLE
Add Node.js module caching to GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
+      - name: Cache Node.js modules
+        uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - run: yarn 
       - run: yarn build
       - run: yarn test


### PR DESCRIPTION
This shaves ~20 seconds of the builds, so they now run twice as fast (though they were admittedly fast to begin with, around 40 seconds).