### PR TITLE
Improve detection of definitions

### DIFF
--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -20,6 +20,7 @@ const plainid = `(?:${idrest}|${opchar}+)`
 const backQuotedId = "`[^`]+`"
 const anyId = `(?:${plainid}|${backQuotedId})`
 const endOfLineMaybeWithComment = "(?=\\s*(//.*|/\\*(?!.*\\*/\\s*\\S.*).*)?$)"
+const notStartOfComment = "(?!//|/\\*)"
 
 export const scalaTmLanguage: TmLanguage = {
   fileTypes: [
@@ -616,7 +617,7 @@ export const scalaTmLanguage: TmLanguage = {
     declarations: {
       patterns: [
         {
-          match: `(?x)\\b(def)\\s+(${backQuotedId}|${plainid})`,
+          match: `\\b(def)\\b\\s*${notStartOfComment}(${anyId})?`,
           captures: {
             '1': {
               name: 'keyword.declaration.scala'
@@ -627,7 +628,7 @@ export const scalaTmLanguage: TmLanguage = {
           }
         },
         {
-          match: `\\b(trait)\\s+([^\\s\\{\\(\\[;]+)(?<![^${opchar}]:)`,
+          match: `\\b(trait)\\b\\s*${notStartOfComment}(${anyId})?`,
           captures: {
             '1': {
               name: 'keyword.declaration.scala'
@@ -638,7 +639,7 @@ export const scalaTmLanguage: TmLanguage = {
           }
         },
         {
-          match: `\\b(?:(case)\\s+)?(class|object|enum)\\s+([^\\s\\{\\(\\[;]+)(?<![^${opchar}]:)`,
+          match: `\\b(?:(case)\\s+)?(class|object|enum)\\b\\s*${notStartOfComment}(${anyId})?`,
           captures: {
             '1': {
               name: 'keyword.declaration.scala'
@@ -652,7 +653,7 @@ export const scalaTmLanguage: TmLanguage = {
           }
         },
         {
-          match: `(?<!\\.)\\b(type)\\s+(${backQuotedId}|${plainid})`,
+          match: `(?<!\\.)\\b(type)\\b\\s*${notStartOfComment}(${anyId})?`,
           captures: {
             '1': {
               name: 'keyword.declaration.scala'
@@ -663,7 +664,7 @@ export const scalaTmLanguage: TmLanguage = {
           }
         },
         { // val (x1, x2) = tup // val Some(x) = opt
-          match: `\\b(?:(val)|(var))(?=\\s+(${anyId})?\\()`,
+          match: `\\b(?:(val)|(var))\\b\\s*${notStartOfComment}(?=${anyId}?\\()`,
           captures: {
             '1': {
               name: 'keyword.declaration.stable.scala'
@@ -674,7 +675,7 @@ export const scalaTmLanguage: TmLanguage = {
           }
         },
         { // val x1, x2 = y
-          match: `\\b(?:(val)|(var))\\s+(?:${anyId})(?=\\s*,)`,
+          match: `\\b(?:(val)|(var))\\b\\s*${notStartOfComment}${anyId}(?=\\s*,)`,
           captures: {
             '1': {
               name: 'keyword.declaration.stable.scala'
@@ -685,7 +686,7 @@ export const scalaTmLanguage: TmLanguage = {
           }
         },
         {
-          match: `\\b(?:(val)|(var))\\s+(${anyId})`,
+          match: `\\b(?:(val)|(var))\\b\\s*${notStartOfComment}(${anyId})?`,
           captures: {
             '1': {
               name: 'keyword.declaration.stable.scala'
@@ -699,7 +700,7 @@ export const scalaTmLanguage: TmLanguage = {
           }
         },
         {
-          match: '\\b(package)\\s+(object)\\s+([^\\s\\{\\(\\[]+)',
+          match: `\\b(package)\\s+(object)\\b\\s*${notStartOfComment}(${anyId})?`,
           captures: {
             '1': {
               name: 'keyword.other.scoping.scala'
@@ -736,7 +737,7 @@ export const scalaTmLanguage: TmLanguage = {
           name: 'meta.package.scala'
         },
         {
-          match: `\\b(given)(?:\\s+(${idLower}|${backQuotedId}))?`,
+          match: `\\b(given)\\b\\s*(${idLower}|${backQuotedId})?`,
           captures: {
             '1': { name: 'keyword.declaration.scala' },
             '2': { name: 'entity.name.given.declaration' }

--- a/tests/snap/backticks.test.scala.snap
+++ b/tests/snap/backticks.test.scala.snap
@@ -2,8 +2,8 @@
 >object `Backtics test` {
 #^^^^^^ source.scala keyword.declaration.scala
 #      ^ source.scala
-#       ^^^^^^^^^ source.scala entity.name.class.declaration
-#                ^^^^^^^ source.scala
+#       ^^^^^^^^^^^^^^^ source.scala entity.name.class.declaration
+#                      ^ source.scala
 #                       ^ source.scala punctuation.section.block.begin.scala
 >    val x = MediaRange.`*/*`
 #^^^^ source.scala

--- a/tests/unit/definitions-with-nested-comments.test.scala
+++ b/tests/unit/definitions-with-nested-comments.test.scala
@@ -1,0 +1,73 @@
+// SYNTAX TEST "source.scala"
+
+   def // comment
+// ^^^ keyword.declaration.scala
+//     ^^^^^^^^^^ comment.line.double-slash.scala
+
+   def /* comment */
+// ^^^ keyword.declaration.scala
+//     ^^^^^^^^^^^^^ comment.block.scala
+
+   val // comment
+// ^^^ keyword.declaration.stable.scala
+//     ^^^^^^^^^^ comment.line.double-slash.scala
+
+   val /* comment */
+// ^^^ keyword.declaration.stable.scala
+//     ^^^^^^^^^^^^^ comment.block.scala
+
+   var // comment
+// ^^^ keyword.declaration.volatile.scala
+//     ^^^^^^^^^^ comment.line.double-slash.scala
+
+   var /* comment */
+// ^^^ keyword.declaration.volatile.scala
+//     ^^^^^^^^^^^^^ comment.block.scala
+
+   given // comment
+// ^^^^^ keyword.declaration.scala
+//       ^^^^^^^^^^ comment.line.double-slash.scala
+
+   given /* comment */
+// ^^^^^ keyword.declaration.scala
+//       ^^^^^^^^^^^^^ comment.block.scala
+
+   class // comment
+// ^^^^^ keyword.declaration.scala
+//       ^^^^^^^^^^ comment.line.double-slash.scala
+
+   class /* comment */
+// ^^^^^ keyword.declaration.scala
+//       ^^^^^^^^^^^^^ comment.block.scala
+
+   trait // comment
+// ^^^^^ keyword.declaration.scala
+//       ^^^^^^^^^^ comment.line.double-slash.scala
+
+   trait /* comment */
+// ^^^^^ keyword.declaration.scala
+//       ^^^^^^^^^^^^^ comment.block.scala
+
+   object // comment
+// ^^^^^^ keyword.declaration.scala
+//        ^^^^^^^^^^ comment.line.double-slash.scala
+
+   object /* comment */
+// ^^^^^^ keyword.declaration.scala
+//        ^^^^^^^^^^^^^ comment.block.scala
+
+   enum // comment
+// ^^^^ keyword.declaration.scala
+//      ^^^^^^^^^^ comment.line.double-slash.scala
+
+   enum /* comment */
+// ^^^^ keyword.declaration.scala
+//      ^^^^^^^^^^^^^ comment.block.scala
+
+   type // comment
+// ^^^^ keyword.declaration.scala
+//      ^^^^^^^^^^ comment.line.double-slash.scala
+
+   type /* comment */
+// ^^^^ keyword.declaration.scala
+//      ^^^^^^^^^^^^^ comment.block.scala

--- a/tests/unit/fast-definitions.test.scala
+++ b/tests/unit/fast-definitions.test.scala
@@ -1,0 +1,45 @@
+// SYNTAX TEST "source.scala"
+
+
+   val
+// ^^^ keyword.declaration.stable.scala
+
+   var
+// ^^^ keyword.declaration.volatile.scala
+
+   def
+// ^^^ keyword.declaration.scala
+
+   type
+// ^^^^ keyword.declaration.scala
+
+   class
+// ^^^^^ keyword.declaration.scala
+
+   trait
+// ^^^^^ keyword.declaration.scala
+
+   object
+// ^^^^^^ keyword.declaration.scala
+
+   given
+// ^^^^^ keyword.declaration.scala
+
+   enum
+// ^^^^ keyword.declaration.scala
+
+   case class
+// ^^^^ keyword.declaration.scala
+//      ^^^^^ keyword.declaration.scala
+
+   case object
+// ^^^^ keyword.declaration.scala
+//      ^^^^^^ keyword.declaration.scala
+
+   inline def
+// ^^^^^^ storage.modifier.other
+//        ^^^ keyword.declaration.scala
+
+   package object
+// ^^^^^^^ keyword.other.scoping.scala
+//         ^^^^^^ keyword.declaration.scala

--- a/tests/unit/given.test.scala
+++ b/tests/unit/given.test.scala
@@ -107,3 +107,6 @@
 //               ^^ variable.parameter.scala
 //                   ^^ entity.name.class
 //                        ^^^ entity.name.class
+
+    givenx
+//  ^^^^^ - keyword.declaration.scala


### PR DESCRIPTION
This makes definitions highlight before the name is typed, as it happens with all other keywords.

Also fix corner case where a comment is inserted just after a `val`, `def`, ...