### PR TITLE
Properly highlight escape characters in `raw` interpolator

### DIFF
--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -332,6 +332,36 @@ export const scalaTmLanguage: TmLanguage = {
           name: 'string.quoted.triple.scala'
         },
         {
+          begin: `\\b(raw)(""")`,
+          end: '"""(?!")',
+          beginCaptures: {
+            '1': {
+              name: 'keyword.interpolation.scala'
+            },
+            '2': {
+              name: 'string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala'
+            }
+          },
+          patterns: [
+            {
+              match: "\\$[\\$\"]",
+              name: 'constant.character.escape.scala'
+            },
+            {
+              "include": "#string-interpolation"
+            },
+            {
+              match: '.',
+              name: 'string.quoted.triple.interpolated.scala'
+            }
+          ],
+          endCaptures: {
+            '0': {
+              name: 'string.quoted.triple.interpolated.scala punctuation.definition.string.end.scala'
+            }
+          }
+        },
+        {
           begin: `\\b(${alphaId})(""")`,
           end: '"""(?!")',
           beginCaptures: {
@@ -385,6 +415,36 @@ export const scalaTmLanguage: TmLanguage = {
             }
           },
           name: 'string.quoted.double.scala'
+        },
+        {
+          begin: `\\b(raw)(")`,
+          end: '"',
+          beginCaptures: {
+            '1': {
+              name: 'keyword.interpolation.scala'
+            },
+            '2': {
+              name: 'string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala'
+            }
+          },
+          patterns: [
+            {
+              match: "\\$[\\$\"]",
+              name: 'constant.character.escape.scala'
+            },
+            {
+              include: "#string-interpolation"
+            },
+            {
+              match: '.',
+              name: 'string.quoted.double.interpolated.scala'
+            }
+          ],
+          endCaptures: {
+            '0': {
+              name: 'string.quoted.double.interpolated.scala punctuation.definition.string.end.scala'
+            }
+          }
         },
         {
           begin: `\\b(${alphaId})(")`,

--- a/tests/unit/#183.test.scala
+++ b/tests/unit/#183.test.scala
@@ -14,14 +14,14 @@
 //      ^^ - constant.character.escape.scala
 //        ^ punctuation.definition.string.end.scala
    
-    raw"$$ " // `$"` is an escaped `"` in raw interpolators
+    raw"$$ " // `$$` is an escaped `$` in raw interpolators
 //  ^^^ source.scala keyword.interpolation.scala
 //     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
 //      ^^ constant.character.escape.scala
 //        ^ string.quoted.double.interpolated.scala
 //         ^ punctuation.definition.string.end.scala
 
-    raw"$" " // `$$` is an escaped `$` in raw interpolators
+    raw"$" " // `$"` is an escaped `"` in raw interpolators
 //  ^^^ source.scala keyword.interpolation.scala
 //     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
 //      ^^ constant.character.escape.scala

--- a/tests/unit/#183.test.scala
+++ b/tests/unit/#183.test.scala
@@ -1,0 +1,76 @@
+// SYNTAX TEST "source.scala"
+
+
+    s"\\"
+//  ^ source.scala keyword.interpolation.scala
+//   ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//    ^^ constant.character.escape.scala
+//      ^ punctuation.definition.string.end.scala
+
+    raw"\\"
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//      ^^ string.quoted.double.interpolated.scala
+//      ^^ - constant.character.escape.scala
+//        ^ punctuation.definition.string.end.scala
+   
+    raw"$$ " // `$"` is an escaped `"` in raw interpolators
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//      ^^ constant.character.escape.scala
+//        ^ string.quoted.double.interpolated.scala
+//         ^ punctuation.definition.string.end.scala
+
+    raw"$" " // `$$` is an escaped `$` in raw interpolators
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//      ^^ constant.character.escape.scala
+//        ^ string.quoted.double.interpolated.scala
+//         ^ punctuation.definition.string.end.scala
+
+    raw"${4} "
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//      ^^  meta.template.expression.scala punctuation.definition.template-expression.begin.scala
+//        ^ meta.template.expression.scala meta.embedded.line.scala constant.numeric.scala
+//         ^ meta.template.expression.scala punctuation.definition.template-expression.end.scala
+//          ^ string.quoted.double.interpolated.scala
+//           ^ punctuation.definition.string.end.scala
+
+
+    s"""\\"""
+//  ^ source.scala keyword.interpolation.scala
+//   ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//      ^^ constant.character.escape.scala
+//        ^^^ punctuation.definition.string.end.scala
+
+    raw"""\\"""
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//        ^^ string.quoted.triple.interpolated.scala
+//        ^^ - constant.character.escape.scala
+//          ^^^ punctuation.definition.string.end.scala
+
+    raw"""$$ """
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//        ^^ constant.character.escape.scala
+//          ^ string.quoted.triple.interpolated.scala
+//           ^^^ punctuation.definition.string.end.scala
+
+    raw"""$" """
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//        ^^ constant.character.escape.scala
+//          ^ string.quoted.triple.interpolated.scala
+//           ^^^ punctuation.definition.string.end.scala
+
+
+    raw"""${4} """
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//        ^^  meta.template.expression.scala punctuation.definition.template-expression.begin.scala
+//          ^ meta.template.expression.scala meta.embedded.line.scala constant.numeric.scala
+//           ^ meta.template.expression.scala punctuation.definition.template-expression.end.scala
+//            ^ string.quoted.triple.interpolated.scala
+//             ^^^ punctuation.definition.string.end.scala


### PR DESCRIPTION
Only `$$` and `$"` are escaped in `raw` interpolators. `$"` only in Scala 3.

<img width="115" alt="Screenshot 2021-01-15 at 17 22 20" src="https://user-images.githubusercontent.com/3648029/104751891-44eb3000-5756-11eb-92b9-8c5108f8af2a.png">
