### PR TITLE
Fix letterOrDigitNoDollarSigns regex

### DIFF
--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -10,7 +10,7 @@ const letter = `[${letterChars}]`
 const letterOrDigitChars = `${letterChars}0-9`
 const letterOrDigit = `[${letterOrDigitChars}]`
 const alphaId = `${letter}+`
-const letterOrDigitNoDollarSign = `[${letterOrDigit.replace("\\$", "")}]`
+const letterOrDigitNoDollarSign = letterOrDigit.replace("\\$", "")
 const simpleInterpolatedVariable  = `${letter}${letterOrDigitNoDollarSign}*` // see SIP-11 https://docs.scala-lang.org/sips/string-interpolation.html
 const opchar = `[!#%&*+\\-\\/:<>=?@^|~\\p{Sm}\\p{So}]`
 const idrest = `${letter}${letterOrDigit}*(?:(?<=_)${opchar}+)?`


### PR DESCRIPTION
On master, this regex evaluates to `[[A-Z\\p{Lt}\\p{Lu}_a-z\\p{Lo}\\p{Nl}\\p{Ll}0-9]]`. The way this regex should be parsed is that the first `[` opens a character set which includes `[`. The first `]` then closes the character set. The character set should then be followed by `]`. In `simpleInterpolatedVariable`, the `*` then applies to the second `]`.

This PR fixes that to remove the duplicated `[` and `]`. 

Here's something weird though: I cannot find an example where the current version produces a wrong highlighting with this regex. The `simpleInterpolatedVariable` regex is currently `[A-Z\\p{Lt}\\p{Lu}_a-z\\$\\p{Lo}\\p{Nl}\\p{Ll}][[A-Z\\p{Lt}\\p{Lu}_a-z\\p{Lo}\\p{Nl}\\p{Ll}0-9]]*` on master. Running this in the command line confirms that the description of the regex I gave above is correct. However, when creating a test for this (and looking at the highlighting in VS Code), I cannot reproduce a bug. I would expect the following to fail on master, but it doesn't...

```scala
   s"$a[ $bc]"
// ^ keyword.interpolation.scala
//  ^ punctuation.definition.string.begin.scala
//   ^ punctuation.definition.template-expression.begin.scala
//    ^ meta.template.expression.scala
//     ^^ source.scala string.quoted.double.interpolated.scala
//       ^ punctuation.definition.template-expression.begin.scala
//        ^^ meta.template.expression.scala
//          ^ source.scala string.quoted.double.interpolated.scala
//           ^ punctuation.definition.string.end.scala
```

However, the above highlighting is wrong on GitHub, exactly in the way I would expect it to be based on the bug that this PR fixes. To see this in action:

```scala
s"test $test test $test] $te] $te]]]]]]"
```

![image](https://user-images.githubusercontent.com/990794/106211618-5d812e80-61c9-11eb-84b7-98c368d61296.png)
