### PR TITLE
Identify illegal $ tokens in string interpolators

### DIFF
--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -418,7 +418,7 @@ export const scalaTmLanguage: TmLanguage = {
         },
         {
           begin: `\\b(raw)(")`,
-          end: `(")|(\\$(?=[^\\$"_{${letterChars}]))`,
+          end: `"|\\$(?=[^\\$"_{${letterChars}])`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -441,17 +441,14 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '1': {
+            '0': {
               name: 'string.quoted.double.interpolated.scala punctuation.definition.string.end.scala'
-            },
-            '2': {
-              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         },
         {
           begin: `\\b(${alphaId})(")`,
-          end: `(")|(\\$(?=[^\\$"_{${letterChars}]))`,
+          end: `"|\\$(?=[^\\$"_{${letterChars}])`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -482,11 +479,8 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '1': {
+            '0': {
               name: 'string.quoted.double.interpolated.scala punctuation.definition.string.end.scala'
-            },
-            '2': {
-              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         }

--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -418,7 +418,7 @@ export const scalaTmLanguage: TmLanguage = {
         },
         {
           begin: `\\b(raw)(")`,
-          end: '"',
+          end: `(")|(\\$(?=[^\\$"_{${letterChars}]))`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -441,14 +441,17 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '0': {
+            '1': {
               name: 'string.quoted.double.interpolated.scala punctuation.definition.string.end.scala'
+            },
+            '2': {
+              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         },
         {
           begin: `\\b(${alphaId})(")`,
-          end: '"',
+          end: `(")|(\\$(?=[^\\$"_{${letterChars}]))`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -458,6 +461,10 @@ export const scalaTmLanguage: TmLanguage = {
             }
           },
           patterns: [
+            {
+              match: "\\$[\\$\"]",
+              name: 'constant.character.escape.scala'
+            },
             {
               include: "#string-interpolation"
             },
@@ -475,8 +482,11 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '0': {
+            '1': {
               name: 'string.quoted.double.interpolated.scala punctuation.definition.string.end.scala'
+            },
+            '2': {
+              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         }

--- a/src/typescript/Scala.tmLanguage.ts
+++ b/src/typescript/Scala.tmLanguage.ts
@@ -333,7 +333,7 @@ export const scalaTmLanguage: TmLanguage = {
         },
         {
           begin: `\\b(raw)(""")`,
-          end: '"""(?!")',
+          end: `(""")(?!")|\\$\n|(\\$[^\\$"_{${letterChars}])`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -356,14 +356,17 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '0': {
+            '1': {
               name: 'string.quoted.triple.interpolated.scala punctuation.definition.string.end.scala'
+            },
+            '2': {
+              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         },
         {
           begin: `\\b(${alphaId})(""")`,
-          end: '"""(?!")',
+          end: `(""")(?!")|\\$\n|(\\$[^\\$"_{${letterChars}])`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -386,8 +389,11 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '0': {
+            '1': {
               name: 'string.quoted.triple.interpolated.scala punctuation.definition.string.end.scala'
+            },
+            '2': {
+              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         },
@@ -418,7 +424,7 @@ export const scalaTmLanguage: TmLanguage = {
         },
         {
           begin: `\\b(raw)(")`,
-          end: `"|\\$(?=[^\\$"_{${letterChars}])`,
+          end: `(")|\\$\n|(\\$[^\\$"_{${letterChars}])`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -441,14 +447,17 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '0': {
+            '1': {
               name: 'string.quoted.double.interpolated.scala punctuation.definition.string.end.scala'
+            },
+            '2': {
+              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         },
         {
           begin: `\\b(${alphaId})(")`,
-          end: `"|\\$(?=[^\\$"_{${letterChars}])`,
+          end: `(")|\\$\n|(\\$[^\\$"_{${letterChars}])`,
           beginCaptures: {
             '1': {
               name: 'keyword.interpolation.scala'
@@ -479,8 +488,11 @@ export const scalaTmLanguage: TmLanguage = {
             }
           ],
           endCaptures: {
-            '0': {
+            '1': {
               name: 'string.quoted.double.interpolated.scala punctuation.definition.string.end.scala'
+            },
+            '2': {
+              name: 'invalid.illegal.unrecognized-string-escape.scala'
             }
           }
         }

--- a/tests/unit/#183.test.scala
+++ b/tests/unit/#183.test.scala
@@ -13,7 +13,7 @@
 //      ^^ string.quoted.double.interpolated.scala
 //      ^^ - constant.character.escape.scala
 //        ^ punctuation.definition.string.end.scala
-   
+
     raw"$$ " // `$$` is an escaped `$` in raw interpolators
 //  ^^^ source.scala keyword.interpolation.scala
 //     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
@@ -74,3 +74,8 @@
 //           ^ meta.template.expression.scala punctuation.definition.template-expression.end.scala
 //            ^ string.quoted.triple.interpolated.scala
 //             ^^^ punctuation.definition.string.end.scala
+
+    raw"$
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//      ^ invalid.illegal.unrecognized-string-escape.scala

--- a/tests/unit/#183.test.scala
+++ b/tests/unit/#183.test.scala
@@ -78,4 +78,4 @@
     raw"$
 //  ^^^ source.scala keyword.interpolation.scala
 //     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//      ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
+//      ^ - string.quoted.double.interpolated.scala punctuation.definition.string.end.scala

--- a/tests/unit/#183.test.scala
+++ b/tests/unit/#183.test.scala
@@ -78,4 +78,4 @@
     raw"$
 //  ^^^ source.scala keyword.interpolation.scala
 //     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//      ^ invalid.illegal.unrecognized-string-escape.scala
+//      ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala

--- a/tests/unit/#195.test.scala
+++ b/tests/unit/#195.test.scala
@@ -30,18 +30,53 @@
 //     ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
 
 
+   s"$
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^ - string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
+//   ^ - constant.character.escape.scala
+
+
    s"$ //
 //  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//   ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
-//     ^^ comment.line.double-slash.scala punctuation.definition.comment.scala
+//   ^^ invalid.illegal.unrecognized-string-escape.scala
 
-   s"$+
+   s"$++
 //  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//   ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
-//    ^ keyword.operator.arithmetic.scala
+//   ^^ invalid.illegal.unrecognized-string-escape.scala
+//     ^ keyword.operator.arithmetic.scala
 
    s"$; val a =
 //  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//   ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
-//    ^^^^^^^^^^ -string.quoted.double.interpolated.scala
+//   ^^ invalid.illegal.unrecognized-string-escape.scala
+//      ^^^^^^^^ -string.quoted.double.interpolated.scala
 //      ^^^ keyword.declaration.stable.scala
+
+    raw"$
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//      ^ - string.quoted.double.interpolated.scala invalid.illegal.unrecognized-string-escape.scala
+
+    raw"$4
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//      ^^ invalid.illegal.unrecognized-string-escape.scala
+
+    raw"""$
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//        ^ - string.quoted.triple.interpolated.scala invalid.illegal.unrecognized-string-escape.scala
+
+    raw"""$8
+//  ^^^ source.scala keyword.interpolation.scala
+//     ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//        ^^ invalid.illegal.unrecognized-string-escape.scala
+
+    s"""$
+//  ^ source.scala keyword.interpolation.scala
+//   ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//      ^ - string.quoted.triple.interpolated.scala invalid.illegal.unrecognized-string-escape.scala
+
+    s"""$8
+//  ^ source.scala keyword.interpolation.scala
+//   ^^^ string.quoted.triple.interpolated.scala punctuation.definition.string.begin.scala
+//      ^^ invalid.illegal.unrecognized-string-escape.scala

--- a/tests/unit/#195.test.scala
+++ b/tests/unit/#195.test.scala
@@ -32,16 +32,16 @@
 
    s"$ //
 //  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//   ^ invalid.illegal.unrecognized-string-escape.scala
+//   ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
 //     ^^ comment.line.double-slash.scala punctuation.definition.comment.scala
 
    s"$+
 //  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//   ^ invalid.illegal.unrecognized-string-escape.scala
+//   ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
 //    ^ keyword.operator.arithmetic.scala
 
    s"$; val a =
 //  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
-//   ^ invalid.illegal.unrecognized-string-escape.scala
+//   ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
 //    ^^^^^^^^^^ -string.quoted.double.interpolated.scala
 //      ^^^ keyword.declaration.stable.scala

--- a/tests/unit/#195.test.scala
+++ b/tests/unit/#195.test.scala
@@ -1,0 +1,47 @@
+// SYNTAX TEST "source.scala"
+
+   s"$a"
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^ meta.template.expression.scala punctuation.definition.template-expression.begin.scala
+//    ^ meta.template.expression.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
+
+   s"${a}"
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^^ meta.template.expression.scala punctuation.definition.template-expression.begin.scala
+//     ^ meta.template.expression.scala
+//      ^ meta.template.expression.scala punctuation.definition.template-expression.end.scala
+//       ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
+
+   s"$_"
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^ source.scala meta.template.expression.scala punctuation.definition.template-expression.begin.scala
+//    ^ source.scala meta.template.expression.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
+
+   s"$$"
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^^ constant.character.escape.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
+
+   s"$""
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^^ constant.character.escape.scala
+//     ^ string.quoted.double.interpolated.scala punctuation.definition.string.end.scala
+
+
+   s"$ //
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^ invalid.illegal.unrecognized-string-escape.scala
+//     ^^ comment.line.double-slash.scala punctuation.definition.comment.scala
+
+   s"$+
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^ invalid.illegal.unrecognized-string-escape.scala
+//    ^ keyword.operator.arithmetic.scala
+
+   s"$; val a =
+//  ^ string.quoted.double.interpolated.scala punctuation.definition.string.begin.scala
+//   ^ invalid.illegal.unrecognized-string-escape.scala
+//    ^^^^^^^^^^ -string.quoted.double.interpolated.scala
+//      ^^^ keyword.declaration.stable.scala


### PR DESCRIPTION
Fixes #195

Scala 2 stops parsing after one of these failures. It does not matter how we highlight the rest.

Scala 3 continues parsing assuming the string has been closed. Highlighting the following code as if the string was closed helps to understand the following parsing errors.

<img width="117" alt="Screenshot 2021-01-29 at 15 46 26" src="https://user-images.githubusercontent.com/3648029/106289115-28b4bc00-6249-11eb-8bb8-827e0001ae3f.png">