### PR TITLE
Remove extensionKind so that other extensions can depend on scala-syntax via SSH/WSL2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,6 @@
     "engines": {
         "vscode": "^1.5.0"
     },
-    "extensionKind": [
-        "ui",
-        "web"
-    ],
     "homepage": "https://github.com/scala/vscode-scala-syntax/blob/main/README.md",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Based on feedback in https://github.com/microsoft/vscode/issues/128375#issuecomment-878096917