### PR TITLE
Add auth token to github-changes command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Update package.json version
         run: yarn version --no-git-tag-version --new-version ${GITHUB_REF#refs/*/}
       - name: Generate CHANGELOG.md
-        run: yarn run github-changes --owner $OWNER --repository $REPOSITORY --branch $RELEASE_BRANCH --no-merges --title "Scala Syntax (official) Changelog"
+        run: yarn run github-changes --token ${{ secrets.GITHUB_TOKEN }} --owner $OWNER --repository $REPOSITORY --branch $RELEASE_BRANCH --no-merges --title "Scala Syntax (official) Changelog"
       - run: yarn build
       - run: yarn test
       # - name: Commit generated files


### PR DESCRIPTION
Fixes the problem that happened in this deployment run: https://github.com/scala/vscode-scala-syntax/runs/3046696346

Don't know why this was broken, but hopefully this should fix it.