### PR TITLE
Fix GitHub Releases deployment command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy
 on:
   push:
     tags:
-      - '*.*.*'
+      - "*.*.*"
 
 env:
   OWNER: scala
@@ -41,7 +41,7 @@ jobs:
         run: yarn vscode:publish --pat ${{ secrets.VS_MARKETPLACE_TOKEN }}
 
       - name: Generate GitHub Release notes
-        run: yarn run github-changes --owner $OWNER --repository $REPOSITORY --branch $RELEASE_BRANCH --no-merges --title "Changelog" --for-tag ${GITHUB_REF#refs/*/} --file release-notes.md
+        run: yarn run github-changes --token ${{ secrets.GITHUB_TOKEN }} --owner $OWNER --repository $REPOSITORY --branch $RELEASE_BRANCH --no-merges --title "Changelog" --for-tag ${GITHUB_REF#refs/*/} --file release-notes.md
       - name: Create GitHub Release
         id: create-release
         uses: actions/create-release@v1


### PR DESCRIPTION
Fixed the first one in #211, but forgot to fix the second one. The deployment build of 0.5.4 therefore [failed](https://github.com/scala/vscode-scala-syntax/runs/3059897029) when creating the release notes (though after publishing 0.5.4 -- only the release notes failed).