### PR TITLE
Uncomment CI push of generated files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy
 on:
   push:
     tags:
-      - '*.*.*'
+      - "*.*.*"
 
 env:
   OWNER: scala
@@ -29,13 +29,15 @@ jobs:
         run: yarn run github-changes --token ${{ secrets.GITHUB_TOKEN }} --owner $OWNER --repository $REPOSITORY --branch $RELEASE_BRANCH --no-merges --title "Scala Syntax (official) Changelog"
       - run: yarn build
       - run: yarn test
-      # - name: Commit generated files
-      #   run: |
-      #     git config --global user.name "Scala bot"
-      #     git config --global user.email "$GITHUB_RUN_NUMBER@$GITHUB_SHA"
-      #     git commit -am "Release ${GITHUB_REF#refs/*/}"
-      #     git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-      #     git push origin HEAD:$RELEASE_BRANCH
+
+      # Comment this out if it causes problems...
+      - name: Commit generated files
+        run: |
+          git config --global user.name "Scala bot"
+          git config --global user.email "$GITHUB_RUN_NUMBER@$GITHUB_SHA"
+          git commit -am "Release ${GITHUB_REF#refs/*/}"
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          git push origin HEAD:$RELEASE_BRANCH
 
       - name: Release extension
         run: yarn vscode:publish --pat ${{ secrets.VS_MARKETPLACE_TOKEN }}


### PR DESCRIPTION
I tested this on my repo and it worked (though only when tagging the tip of the branch, this will fail if we tag anything else).

This was previously causing problems, but I think that we had other issues with the CI too, so maybe those were linked failures. If we run this command, we'll at least find out what happens now!

If this causes problems again, we can comment it out again. But at least we'll then have some CI logs to look into -- the old CI logs from back when this was first commented out are gone, so I couldn't look at those to try to understand why this was failing back then.