### PR TITLE
Scala Syntax extension should not be installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "engines": {
         "vscode": "^1.5.0"
     },
+    "extensionKind": [
+        "workspace"
+    ],
     "homepage": "https://github.com/scala/vscode-scala-syntax/blob/main/README.md",
     "repository": {
         "type": "git",


### PR DESCRIPTION
In #210, we removed `extensionKind`, so the `extensionKind` becomes the default value `ui,workspace,web`, which is not correct, because `ui` means it will be installed globally, while this extension should be enable for Scala workspaces only.

This PR changes `extensionKind` to `workspace`, allowing the extension being selectively enabled according to workspace languages.