### PR TITLE
Claim *.mill files as Scala files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
                 "extensions": [
                     ".scala",
                     ".sbt",
-                    ".sc"
+                    ".sc",
+                    ".mill"
                 ],
                 "configuration": "./language-configuration.json"
             }


### PR DESCRIPTION
[Mill](https://github.com/com-lihaoyi/mill) is now claiming `.mill` files as its own, to avoid the confusion with the Ammonite and Scala CLI `.sc` files. These are still Scala files, and should have Scala syntax support.

Related to https://github.com/com-lihaoyi/mill/pull/3426, https://github.com/scalameta/metals/pull/6752, https://github.com/JetBrains/intellij-scala/pull/666