### PR TITLE
Fix exclusion of project files

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,5 +4,6 @@
 tests/**
 src/**
 node_modules
-.gitkeep
-scripts
+**/.gitkeep
+project/
+.github/


### PR DESCRIPTION
Hello, while playing around with the extension is saw that included more files in its build than nessary.

`vsce ls --yarn` shows now:
- CHANGELOG.md
- images/smooth-spiral.png
- language-configuration.json
- LICENSE.md
- package.json
- README.md
- syntaxes/Scala.tmLanguage.json

Before it included also:
- .github/workflows/cla.yml
- .github/workflows/continuous-integration.yml
- .github/workflows/deploy.yml
- project/scripts/check-cla.sh
- syntaxes/.gitkeep