### PR TITLE
Auto-close backticks

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -20,6 +20,7 @@
         ["s\"", "\""],
         ["f\"", "\""],
         ["raw\"", "\""],
+        ["`", "`"]
     ],
     // symbols that that can be used to surround a selection
     "surroundingPairs": [
@@ -27,6 +28,7 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
+        ["'", "'"],
+        ["`", "`"]
     ]
 }


### PR DESCRIPTION
Typing a backtick now automatically adds a closing backtick as well. Also possible to quickly add backticks around idents by selecting and typing backtick.

Fixes #279